### PR TITLE
Fix telescope's goto_file_selection_edit

### DIFF
--- a/lua/sqls/pickers.lua
+++ b/lua/sqls/pickers.lua
@@ -34,7 +34,7 @@ function M.telescope(switch_callback, choices)
             },
             sorter = conf.generic_sorter({}),
             attach_mappings = function(prompt_bufnr)
-                actions.goto_file_selection_edit:replace(function()
+                actions.select_default:replace(function()
                     local selection = actions.get_selected_entry()
                     actions.close(prompt_bufnr)
                     switch_callback(selection.value)


### PR DESCRIPTION
Thank you for creating this plugin!

I was trying to setup telescope as the picker and bumped into this error

```
Error executing vim.schedule lua callback: ...paqs/start/telesc
ope.nvim/lua/telescope/actions/init.lua:26: `goto_file_selectio
n_edit` is removed and no longer usable. Use `require('telescop
e.actions').select_` instead. Take a look at developers.md for
more Information.
```

It seems that telescope.nvim deprecated `goto_file_selection_edit` API in https://github.com/nvim-telescope/telescope.nvim/pull/472 and the fix is pretty straightforward, so I took the liberty of creating this PR.
