### PR TITLE
Rethink the design of `executeQuery`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ require'lspconfig'.sqls.setup{
 
 Available commands:
 
-- `:SqlsExecuteQuery`: In normal mode, executes the query in the current buffer. In visual mode, executes the selected query. Shows the results in a preview buffer.
+- `:SqlsExecuteQuery`: In normal mode, executes the query in the current buffer. In visual mode, executes the selected query (only works line-wise). Shows the results in a preview buffer.
 - `:SqlsExecuteQueryVertical`: Same as `:SqlsExecuteQuery`, but the results are displayed vertically.
 - `:SqlsShowDatabases`: Shows a list of available databases in a preview buffer.
 - `:SqlsShowSchemas`: Shows a list of available schemas in a preview buffer.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Available commands:
 
 Commands using a preview buffer also support modifiers like `:vertical` or `:tab`.
 
+Available mappings:
+
+- `<Plug>(sqls-execute-query)`: In visual mode, executes the selected range. In normal mode, executes a motion (like `ip` or `aw`)
+- `<Plug>(sqls-execute-query-vertical)`: same as `<Plug>(sqls-execute-query)`, but the results are displayed vertically
+
 ## Configuration
 
 The plugin can be configured by passing a table to the `setup()` function. Available options:

--- a/lua/sqls/commands.lua
+++ b/lua/sqls/commands.lua
@@ -16,14 +16,20 @@ local function show_results_handler(mods)
     end
 end
 
-function M.exec(command, mods, range_given, show_vertical)
+function M.exec(command, mods, range_given, show_vertical, line1, line2)
+    local range
+    if range_given then
+        range = vim.lsp.util.make_given_range_params({line1, 0}, {line2, math.huge}).range
+        range['end'].character = range['end'].character - 1
+    end
+
     vim.lsp.buf_request(
         0,
         'workspace/executeCommand',
         {
             command = command,
             arguments = {vim.uri_from_bufnr(0), show_vertical},
-            range = range_given and vim.lsp.util.make_given_range_params().range or nil,
+            range = range,
         },
         show_results_handler(mods)
         )

--- a/lua/sqls/init.lua
+++ b/lua/sqls/init.lua
@@ -8,8 +8,8 @@ M.setup = function(opts)
         return (pickers[opts.picker] or pickers.default)(...)
     end
 
-    vim.cmd [[command! -buffer -range SqlsExecuteQuery lua require'sqls.commands'.exec('executeQuery', '<mods>', <range> ~= 0, nil)]]
-    vim.cmd [[command! -buffer -range SqlsExecuteQueryVertical lua require'sqls.commands'.exec('executeQuery', '<mods>', <range> ~= 0, '-show-vertical')]]
+    vim.cmd [[command! -buffer -range SqlsExecuteQuery lua require'sqls.commands'.exec('executeQuery', '<mods>', <range> ~= 0, nil, <line1>, <line2>)]]
+    vim.cmd [[command! -buffer -range SqlsExecuteQueryVertical lua require'sqls.commands'.exec('executeQuery', '<mods>', <range> ~= 0, '-show-vertical', <line1>, <line2>)]]
     vim.cmd [[command! -buffer SqlsShowDatabases lua require'sqls.commands'.exec('showDatabases', '<mods>')]]
     vim.cmd [[command! -buffer SqlsShowSchemas lua require'sqls.commands'.exec('showSchemas', '<mods>')]]
     vim.cmd [[command! -buffer SqlsShowConnections lua require'sqls.commands'.exec('showConnections', '<mods>')]]

--- a/lua/sqls/init.lua
+++ b/lua/sqls/init.lua
@@ -18,6 +18,11 @@ M.setup = function(opts)
     -- vim.cmd [[command! -buffer SqlsDescribeTable lua require'sqls.commands'.exec('describeTable', '<mods>')]]
     vim.cmd [[command! -buffer -nargs=? SqlsSwitchDatabase lua require'sqls.commands'.switch_database(<f-args>)]]
     vim.cmd [[command! -buffer -nargs=? SqlsSwitchConnection lua require'sqls.commands'.switch_connection(<f-args>)]]
+
+    vim.api.nvim_buf_set_keymap(0, 'n', '<Plug>(sqls-execute-query)', "<Cmd>set opfunc=v:lua.require'sqls.commands'.query<CR>g@", {silent = true})
+    vim.api.nvim_buf_set_keymap(0, 'x', '<Plug>(sqls-execute-query)', "<Cmd>set opfunc=v:lua.require'sqls.commands'.query<CR>g@", {silent = true})
+    vim.api.nvim_buf_set_keymap(0, 'n', '<Plug>(sqls-execute-query-vertical)', "<Cmd>set opfunc=v:lua.require'sqls.commands'.query_vertical<CR>g@", {silent = true})
+    vim.api.nvim_buf_set_keymap(0, 'x', '<Plug>(sqls-execute-query-vertical)', "<Cmd>set opfunc=v:lua.require'sqls.commands'.query_vertical<CR>g@", {silent = true})
 end
 
 return M


### PR DESCRIPTION
BREAKING CHANGE: Ex commands don't support char-wise ranges. The previous design was a mistake as only mappings are an appropriate means to handle char-wise operations.

Passing manual ranges like `:1,10` to the command now works as expected.

This PR also adds mappings for `executeQuery`