### PR TITLE
fix(handler): nil result causing crash

### DIFF
--- a/lua/sqls/commands.lua
+++ b/lua/sqls/commands.lua
@@ -11,6 +11,9 @@ local function make_show_results_handler(mods)
             vim.notify('sqls: ' .. err.message, vim.log.levels.ERROR)
             return
         end
+        if not result then
+            return
+        end
         local tempfile = fn.tempname() .. '.sqls_output'
         local bufnr = fn.bufnr(tempfile, true)
         api.nvim_buf_set_lines(bufnr, 0, 1, false, vim.split(result, '\n'))
@@ -73,6 +76,9 @@ local function make_choice_handler(switch_function, answer_formatter)
     return function(err, result, _, _)
         if err then
             vim.notify('sqls: ' .. err.message, vim.log.levels.ERROR)
+            return
+        end
+        if not result then
             return
         end
         if result == '' then


### PR DESCRIPTION
I'm not sure why this happens on my setup, but the crash might be hooking into the handlers by one of the plugins.

## Stack trace

### Switching connections

```lua
Error executing vim.schedule lua callback: vim/shared.lua:0: s: expected string, got nil                                                                                                                                         
stack traceback:                                                                                                                                                                                                                 
        [C]: in function 'error'                                                                                                                                                                                                 
        vim/shared.lua: in function 'validate'                                                                                                                                                                                   
        vim/shared.lua: in function 'gsplit'                                                                                                                                                                                     
        vim/shared.lua: in function 'split'                                                                                                                                                                                      
        ...vim/site/pack/packer/opt/sqls.nvim/lua/sqls/commands.lua:82: in function 'handler'                                                                                                                                    
        /usr/share/nvim/runtime/lua/vim/lsp.lua:995: in function ''                                                                                                                                                              
        vim.lua: in function <vim.lua:0>
```

### Executing query

```lua
Error executing vim.schedule lua callback: vim/shared.lua:0: s: expected string, got nil                                                                                                                                         
stack traceback:                                                                                                                                                                                                                 
        [C]: in function 'error'                                                                                                                                                                                                 
        vim/shared.lua: in function 'validate'                                                                                                                                                                                   
        vim/shared.lua: in function 'gsplit'                                                                                                                                                                                     
        vim/shared.lua: in function 'split'                                                                                                                                                                                      
        ...vim/site/pack/packer/opt/sqls.nvim/lua/sqls/commands.lua:16: in function 'handler'                                                                                                                                    
        /usr/share/nvim/runtime/lua/vim/lsp.lua:995: in function ''                                                                                                                                                              
        vim.lua: in function <vim.lua:0>  
```