### PR TITLE
feat(commands): connection status support for status bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ Available mappings:
 
 - `<Plug>(sqls-execute-query)`: In visual mode, executes the selected range. In normal mode, executes a motion (like `ip` or `aw`)
 - `<Plug>(sqls-execute-query-vertical)`: same as `<Plug>(sqls-execute-query)`, but the results are displayed vertically
+
+Status bar support:
+
+After choosing a connection you can ask for the currently selected connection
+and database like this:
+
+```lua
+local status = require("sqls.commands").status
+-- status.connection: name of the connection name in the configuration file
+-- status.database: name of the connected database
+```

--- a/lua/sqls/commands.lua
+++ b/lua/sqls/commands.lua
@@ -127,8 +127,20 @@ local function make_prompt_function(command, answer_formatter)
     end
 end
 
-local function format_database_answer(answer) return answer end
-local function format_connection_answer(answer) return vim.split(answer, ' ')[1] end
+-- @field connection string
+-- @field database string
+M.status = {}
+
+local function format_database_answer(answer)
+  M.status.database = answer
+  return answer
+end
+local function format_connection_answer(answer)
+  M.status.connection = vim.split(answer, ' ')[3]
+  local _, _, name = answer:find("dbname=([^ ]+)")
+  M.status.database = name or "Unknown"
+  return vim.split(answer, ' ')[1]
+end
 
 local database_switch_function = make_switch_function('switchDatabase')
 local connection_switch_function = make_switch_function('switchConnections')


### PR DESCRIPTION
The status object can be used for displaying the current connection and the database in the status bar.

In this example, **timeline_local** is the name of the connection, and **timeline** is the database name:

![1](https://user-images.githubusercontent.com/428611/152029124-10d8d6d1-1c15-4055-8e07-cb0bf2250a36.png)

At the moment this only supports postgres.