### PR TITLE
feat: add otter.nvim integration for embedded SQL in parent buffers

### DIFF
--- a/autoload/sqls_nvim.vim
+++ b/autoload/sqls_nvim.vim
@@ -1,7 +1,7 @@
-function! sqls_nvim#query(type, client_id)
-    call v:lua.require'sqls.commands'.query(a:type, a:client_id)
+function! sqls_nvim#query(type, client_id, bufnr)
+    call v:lua.require'sqls.commands'.query(a:type, a:client_id, a:bufnr)
 endfunction
 
-function! sqls_nvim#query_vertical(type, client_id)
-    call v:lua.require'sqls.commands'.query_vertical(a:type, a:client_id)
+function! sqls_nvim#query_vertical(type, client_id, bufnr)
+    call v:lua.require'sqls.commands'.query_vertical(a:type, a:client_id, a:bufnr)
 endfunction

--- a/lsp/sqls.lua
+++ b/lsp/sqls.lua
@@ -83,7 +83,6 @@ end
 return {
     cmd = { 'sqls' },
     filetypes = { 'sql', 'mysql' },
-    single_file_support = false,
     commands = {
         executeQuery = function(_, client)
             require('sqls.commands').exec(client.client_id, 'executeQuery')

--- a/lsp/sqls.lua
+++ b/lsp/sqls.lua
@@ -1,9 +1,89 @@
 local api = vim.api
 
+local function setup_buffer_commands(bufnr, client_id, effective_bufnr)
+    effective_bufnr = effective_bufnr or bufnr
+
+    api.nvim_buf_create_user_command(bufnr, 'SqlsExecuteQuery', function(args)
+        require('sqls.commands').exec(
+            client_id,
+            'executeQuery',
+            args.smods,
+            args.range ~= 0,
+            nil,
+            args.line1,
+            args.line2,
+            effective_bufnr
+        )
+    end, { range = true })
+    api.nvim_buf_create_user_command(bufnr, 'SqlsExecuteQueryVertical', function(args)
+        require('sqls.commands').exec(
+            client_id,
+            'executeQuery',
+            args.smods,
+            args.range ~= 0,
+            '-show-vertical',
+            args.line1,
+            args.line2,
+            effective_bufnr
+        )
+    end, { range = true })
+    api.nvim_buf_create_user_command(bufnr, 'SqlsShowDatabases', function(args)
+        require('sqls.commands').exec(client_id, 'showDatabases', args.smods, false, nil, nil, nil, effective_bufnr)
+    end, {})
+    api.nvim_buf_create_user_command(bufnr, 'SqlsShowSchemas', function(args)
+        require('sqls.commands').exec(client_id, 'showSchemas', args.smods, false, nil, nil, nil, effective_bufnr)
+    end, {})
+    api.nvim_buf_create_user_command(bufnr, 'SqlsShowConnections', function(args)
+        require('sqls.commands').exec(client_id, 'showConnections', args.smods, false, nil, nil, nil, effective_bufnr)
+    end, {})
+    api.nvim_buf_create_user_command(bufnr, 'SqlsShowTables', function(args)
+        require('sqls.commands').exec(client_id, 'showTables', args.smods, false, nil, nil, nil, effective_bufnr)
+    end, {})
+    -- Not yet supported by the language server:
+    -- api.nvim_buf_create_user_command(bufnr, 'SqlsDescribeTable', function(args)
+    --     require('sqls.commands').exec(client_id, 'describeTable', args.smods, false, nil, nil, nil, effective_bufnr)
+    -- end, {})
+    api.nvim_buf_create_user_command(bufnr, 'SqlsSwitchDatabase', function(args)
+        require('sqls.commands').switch_database(client_id, args.args ~= '' and args.args or nil)
+    end, { nargs = '?' })
+    api.nvim_buf_create_user_command(bufnr, 'SqlsSwitchConnection', function(args)
+        require('sqls.commands').switch_connection(client_id, args.args ~= '' and args.args or nil)
+    end, { nargs = '?' })
+
+    api.nvim_buf_set_keymap(
+        bufnr,
+        'n',
+        '<Plug>(sqls-execute-query)',
+        "<Cmd>let &opfunc='{type -> sqls_nvim#query(type, " .. client_id .. ', ' .. effective_bufnr .. ")}'<CR>g@",
+        { silent = true }
+    )
+    api.nvim_buf_set_keymap(
+        bufnr,
+        'x',
+        '<Plug>(sqls-execute-query)',
+        "<Cmd>let &opfunc='{type -> sqls_nvim#query(type, " .. client_id .. ', ' .. effective_bufnr .. ")}'<CR>g@",
+        { silent = true }
+    )
+    api.nvim_buf_set_keymap(
+        bufnr,
+        'n',
+        '<Plug>(sqls-execute-query-vertical)',
+        "<Cmd>let &opfunc='{type -> sqls_nvim#query_vertical(type, " .. client_id .. ', ' .. effective_bufnr .. ")}'<CR>g@",
+        { silent = true }
+    )
+    api.nvim_buf_set_keymap(
+        bufnr,
+        'x',
+        '<Plug>(sqls-execute-query-vertical)',
+        "<Cmd>let &opfunc='{type -> sqls_nvim#query_vertical(type, " .. client_id .. ', ' .. effective_bufnr .. ")}'<CR>g@",
+        { silent = true }
+    )
+end
+
 return {
     cmd = { 'sqls' },
     filetypes = { 'sql', 'mysql' },
-    single_file_support = true,
+    single_file_support = false,
     commands = {
         executeQuery = function(_, client)
             require('sqls.commands').exec(client.client_id, 'executeQuery')
@@ -32,78 +112,20 @@ return {
     },
     on_attach = function(client, bufnr)
         local client_id = client.id
-        api.nvim_buf_create_user_command(bufnr, 'SqlsExecuteQuery', function(args)
-            require('sqls.commands').exec(
-                client_id,
-                'executeQuery',
-                args.smods,
-                args.range ~= 0,
-                nil,
-                args.line1,
-                args.line2
-            )
-        end, { range = true })
-        api.nvim_buf_create_user_command(bufnr, 'SqlsExecuteQueryVertical', function(args)
-            require('sqls.commands').exec(
-                client_id,
-                'executeQuery',
-                args.smods,
-                args.range ~= 0,
-                '-show-vertical',
-                args.line1,
-                args.line2
-            )
-        end, { range = true })
-        api.nvim_buf_create_user_command(bufnr, 'SqlsShowDatabases', function(args)
-            require('sqls.commands').exec(client_id, 'showDatabases', args.smods)
-        end, {})
-        api.nvim_buf_create_user_command(bufnr, 'SqlsShowSchemas', function(args)
-            require('sqls.commands').exec(client_id, 'showSchemas', args.smods)
-        end, {})
-        api.nvim_buf_create_user_command(bufnr, 'SqlsShowConnections', function(args)
-            require('sqls.commands').exec(client_id, 'showConnections', args.smods)
-        end, {})
-        api.nvim_buf_create_user_command(bufnr, 'SqlsShowTables', function(args)
-            require('sqls.commands').exec(client_id, 'showTables', args.smods)
-        end, {})
-        -- Not yet supported by the language server:
-        -- api.nvim_buf_create_user_command(bufnr, 'SqlsDescribeTable', function(args)
-        --     require('sqls.commands').exec(client_id, 'describeTable', args.smods)
-        -- end, {})
-        api.nvim_buf_create_user_command(bufnr, 'SqlsSwitchDatabase', function(args)
-            require('sqls.commands').switch_database(client_id, args.args ~= '' and args.args or nil)
-        end, { nargs = '?' })
-        api.nvim_buf_create_user_command(bufnr, 'SqlsSwitchConnection', function(args)
-            require('sqls.commands').switch_connection(client_id, args.args ~= '' and args.args or nil)
-        end, { nargs = '?' })
+        setup_buffer_commands(bufnr, client_id, bufnr)
 
-        api.nvim_buf_set_keymap(
-            bufnr,
-            'n',
-            '<Plug>(sqls-execute-query)',
-            "<Cmd>let &opfunc='{type -> sqls_nvim#query(type, " .. client_id .. ")}'<CR>g@",
-            { silent = true }
-        )
-        api.nvim_buf_set_keymap(
-            bufnr,
-            'x',
-            '<Plug>(sqls-execute-query)',
-            "<Cmd>let &opfunc='{type -> sqls_nvim#query(type, " .. client_id .. ")}'<CR>g@",
-            { silent = true }
-        )
-        api.nvim_buf_set_keymap(
-            bufnr,
-            'n',
-            '<Plug>(sqls-execute-query-vertical)',
-            "<Cmd>let &opfunc='{type -> sqls_nvim#query_vertical(type, " .. client_id .. ")}'<CR>g@",
-            { silent = true }
-        )
-        api.nvim_buf_set_keymap(
-            bufnr,
-            'x',
-            '<Plug>(sqls-execute-query-vertical)',
-            "<Cmd>let &opfunc='{type -> sqls_nvim#query_vertical(type, " .. client_id .. ")}'<CR>g@",
-            { silent = true }
-        )
+        -- otter.nvim integration: if this buffer is an otter buffer,
+        -- also create commands on the parent (main) buffer so they are
+        -- accessible from e.g. a Python file containing embedded SQL.
+        local ok, keeper = pcall(require, 'otter.keeper')
+        if ok then
+            for main_nr, raft in pairs(keeper.rafts) do
+                for _, otter_nr in pairs(raft.buffers) do
+                    if otter_nr == bufnr then
+                        setup_buffer_commands(main_nr, client_id, bufnr)
+                    end
+                end
+            end
+        end
     end,
 }

--- a/lua/sqls/commands.lua
+++ b/lua/sqls/commands.lua
@@ -34,15 +34,17 @@ end
 ---@param show_vertical? '-show-vertical'
 ---@param line1? integer
 ---@param line2? integer
-function M.exec(client_id, command, smods, range_given, show_vertical, line1, line2)
+---@param bufnr? integer buffer to use for URI and range (defaults to 0)
+function M.exec(client_id, command, smods, range_given, show_vertical, line1, line2, bufnr)
     local client = assert(vim.lsp.get_client_by_id(client_id))
+    bufnr = bufnr or 0
 
     local range
     if range_given then
         range = vim.lsp.util.make_given_range_params(
             { line1, 0 },
             { line2, math.huge },
-            0,
+            bufnr,
             client.offset_encoding
         ).range
         range['end'].character = range['end'].character - 1
@@ -52,7 +54,7 @@ function M.exec(client_id, command, smods, range_given, show_vertical, line1, li
         'workspace/executeCommand',
         {
             command = command,
-            arguments = { vim.uri_from_bufnr(0), show_vertical },
+            arguments = { vim.uri_from_bufnr(bufnr), show_vertical },
             range = range,
         },
         make_show_results_handler(smods)
@@ -64,7 +66,7 @@ end
 ---@param show_vertical? '-show-vertical'
 ---@return sqls_operatorfunc
 local function make_query_mapping(show_vertical)
-    return function(type, client_id)
+    return function(type, client_id, bufnr)
         local range
         local _, lnum1, col1, _ = unpack(fn.getpos("'["))
         local _, lnum2, col2, _ = unpack(fn.getpos("']"))
@@ -74,12 +76,13 @@ local function make_query_mapping(show_vertical)
         end
 
         local client = assert(vim.lsp.get_client_by_id(client_id))
+        bufnr = bufnr or 0
 
         if type == 'line' then
             range = vim.lsp.util.make_given_range_params(
                 { lnum1, 0 },
                 { lnum2, math.huge },
-                0,
+                bufnr,
                 client.offset_encoding
             ).range
             range['end'].character = range['end'].character - 1
@@ -87,7 +90,7 @@ local function make_query_mapping(show_vertical)
             range = vim.lsp.util.make_given_range_params(
                 { lnum1, col1 - 1 },
                 { lnum2, col2 - 1 },
-                0,
+                bufnr,
                 client.offset_encoding
             ).range
         end
@@ -96,7 +99,7 @@ local function make_query_mapping(show_vertical)
             'workspace/executeCommand',
             {
                 command = 'executeQuery',
-                arguments = { vim.uri_from_bufnr(0), show_vertical },
+                arguments = { vim.uri_from_bufnr(bufnr), show_vertical },
                 range = range,
             },
             make_show_results_handler()


### PR DESCRIPTION
Why:
- Users want sqls.nvim commands available in buffers like Python that contain embedded SQL via otter.nvim.
- The commands existed but referenced a dead client_id, causing assertion failures on execution.

What:
- Detect otter.nvim otter buffers in on_attach and mirror commands onto the parent (main) buffer.
- Add optional bufnr parameter to exec() and query mappings so commands run from a parent buffer use the otter buffer URI and content.
- Update VimScript bridge (sqls_nvim#query) to pass bufnr through.
- Refactor command setup into reusable setup_buffer_commands().

Impact:
- No breaking change for existing SQL buffer usage.
- New behavior: Sqls* commands are now available in otter.nvim parent buffers (e.g. Python) when embedded SQL is present.

AI declaration:
- The changes were made with Kimi K2.5 (OpenCode Go plan)